### PR TITLE
add audit logs for create, update, delete and download of questions

### DIFF
--- a/lib/afterglow/actions/actions.ex
+++ b/lib/afterglow/actions/actions.ex
@@ -1,0 +1,14 @@
+defmodule AfterGlow.Actions do
+  def enum do
+    %{ create: 1, update: 2, delete: 3, download: 4 }
+  end
+
+  def get_value(value) do
+    case value do
+      1 -> "CREATE"
+      2 -> "UPDATE"
+      3 -> "DELETE"
+      4 -> "DOWNLOAD"
+    end
+  end
+end

--- a/lib/afterglow/audit_logs/save.ex
+++ b/lib/afterglow/audit_logs/save.ex
@@ -1,0 +1,20 @@
+defmodule AfterGlow.AuditLogSave do
+  alias AfterGlow.Repo, as: Repo
+  @model AfterGlow.AuditLog
+
+  def delete(_id) do
+    {:error, :not_allowed}
+  end
+
+  def save!(user_id, table_name, action, additional_data) do
+    Repo.insert!(
+      @model.changeset(%@model{}, %{
+        whodunit: user_id,
+        table_name: table_name,
+        action: action,
+        additional_data: additional_data
+      })
+    )
+  end
+end
+

--- a/web/jobs/csv_tasks.ex
+++ b/web/jobs/csv_tasks.ex
@@ -3,6 +3,10 @@ defmodule AfterGlow.CsvTasks do
   alias AfterGlow.Helpers.CsvHelpers
   alias AfterGlow.Mailers.CsvMailer
   alias AfterGlow.Sql.DbConnection
+  alias AfterGlow.AuditLogSave
+  alias AfterGlow.User
+  alias AfterGlow.Actions
+
   import AfterGlow.Sql.QueryRunner, only: [permit_prms_raw_query: 2]
 
   def qb_fetch_and_upload(db_record, params, email, download_limit) do
@@ -13,5 +17,18 @@ defmodule AfterGlow.CsvTasks do
   def raw_fetch_and_upload(db_record, params, email, download_limit) do
     {url, data_preview} = CsvHelpers.fetch_and_upload_wrapper(db_record, params, download_limit)
     CsvMailer.mail(email, url, data_preview)
+
+    # extract table name from params
+    table = params[:table]
+    table_name = table["readable_table_name"]
+
+    # Get user id from email
+    user = Repo.get_by(User, email: email)
+    AuditLogSave.save!(
+          user.id,
+          table_name,
+          Actions.enum[:download],
+          %{ "task" => "download_csv", "email" => email, "s3_url" => url }
+        )
   end
 end

--- a/web/models/audit_logs.ex
+++ b/web/models/audit_logs.ex
@@ -1,0 +1,21 @@
+defmodule AfterGlow.AuditLog do
+  use AfterGlow.Web, :model
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @cast_params [:whodunit, :table_name, :action, :additional_data]
+  @required_params [:whodunit]
+  schema "audit_logs" do
+    field(:whodunit, :integer)
+    field(:table_name, :string)
+    field(:action, :integer)
+    field(:additional_data, :map)
+    timestamps(inserted_at: :inserted_at)
+  end
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @cast_params)
+    |> validate_required(@required_params)
+  end
+end


### PR DESCRIPTION
Adding feature for Audit logs on create, update, delete and download of a question.
lib/afterglow/actions/actions.ex - string integer mapping of action performed.
lib/afterglow/audit_logs/save.ex - function to save the data to db restricting delete operation.
web/controllers/question_controller.ex - added the audit log code in create, update and delete functions.
web/jobs/csv_tasks.ex - added the audit log code in download function.
web/models/audit_logs.ex - audit log model.